### PR TITLE
Fix splitMember

### DIFF
--- a/Recursion/src/BinaryTrees.hs
+++ b/Recursion/src/BinaryTrees.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveFoldable #-}
+{-# OPTIONS_GHC -Wall #-}
 module BinaryTrees where
 import Data.Foldable (toList)
 import Data.Function (on)
@@ -173,9 +174,10 @@ splitMember' x (Bin l v r) =
     case compare x v of
         EQ -> STriple l True r
         LT | STriple l' found l'' <- splitMember' x l
-            -> STriple l' found (l'' `join` r)
+            -> STriple l' found (Bin l'' v r)
         GT -> case splitMember' x r of
-            STriple r' found r'' -> STriple (l `join` r') found r''
+            STriple r' found r'' -> STriple (Bin l v r') found r''
+
 
 -- v in t: (l \/ {v} \/ r) /\ (tl \/ {v} \/ tr)
 -- v not in t: (l \/ {v} \/ r) /\ (tl \/ tr)

--- a/Recursion/tests/BinaryTreesTest.hs
+++ b/Recursion/tests/BinaryTreesTest.hs
@@ -78,7 +78,6 @@ unionStrictlyOrderedList (x:xs) (y:ys)
     | x < y = x : unionStrictlyOrderedList xs (y:ys)
     | otherwise = y : unionStrictlyOrderedList (x:xs) ys
 
-
 prop_union :: Set OrdA -> Set OrdA -> Property
 prop_union s t = 
   valid u .&&.
@@ -94,7 +93,7 @@ prop_splitMember a s =
       ys === toList l .&&.
       zs' === toList r
         where
-          (ys, zs) = span (< a) (toList l)
+          (ys, zs) = span (< a) (toList s)
           zs' = dropWhile (== a) zs
 
 -- FIXME: Gabriel, you should add property tests for the rest of the


### PR DESCRIPTION
Both `splitMember` and its test were wrong. Fix both.