### PR TITLE
Add quasiquoter to annotate tests

### DIFF
--- a/Recursion/Recursion.cabal
+++ b/Recursion/Recursion.cabal
@@ -59,9 +59,12 @@ test-suite Recursion-test
     hs-source-dirs:   tests
     main-is:          BinaryTreesTest.hs
     other-modules:
-      ArbitrarySet
+      ArbitrarySet,
+      TH
     build-depends:    base,
                       containers,
+                      template-haskell,
                       Recursion,
                       QuickCheck,
-                      dump
+                      text,
+                      haskell-src-meta

--- a/Recursion/src/BinaryTrees.hs
+++ b/Recursion/src/BinaryTrees.hs
@@ -79,7 +79,7 @@ that inserts a value into a set, maintaining the order invariant. If the value i
 -}
 insert :: Ord a => a -> Set a -> Set a
 insert x Tip = Bin Tip x Tip
-insert x (Bin l v r) | x == v = t
+insert x t@(Bin l v r) | x == v = t
                        | x < v = Bin (insert x l) v r
                        | otherwise = Bin l v (insert x r)
 

--- a/Recursion/tests/BinaryTreesTest.hs
+++ b/Recursion/tests/BinaryTreesTest.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Main where
 
@@ -8,7 +8,6 @@ module Main where
 import qualified BinaryTrees as S
 import BinaryTrees (Set (..))
 
-import Debug.Dump
 import Test.QuickCheck
 import Test.QuickCheck.Poly (OrdA)
 import System.Exit
@@ -17,6 +16,7 @@ import Data.Foldable (toList, null)
 import qualified Data.List as L
 
 import ArbitrarySet ()
+import TH
 
 -- | A version of S.valid that produces a Property labeling the failure
 -- as being caused by an invalid Set.
@@ -114,11 +114,11 @@ prop_splitMember :: OrdA -> S.Set OrdA -> Property
 prop_splitMember a s =
   case S.splitMember a s of
     (l, found, r) ->
-      (valid l) .&&. 
-      (valid r) .&&.
-      (found === (a `S.member` s)) .&&.
-      ys === toList l .&&.
-      zs' === toList r
+      [ann| valid l |] .&&.
+      [ann| valid r |] .&&.
+      [ann| found === (a `S.member` s) |] .&&.
+      [ann| ys === toList l |] .&&.
+      [ann| zs' === toList r |]
         where
           (ys, zs) = span (< a) (toList s)
           zs' = dropWhile (== a) zs

--- a/Recursion/tests/TH.hs
+++ b/Recursion/tests/TH.hs
@@ -1,0 +1,38 @@
+{-# language TemplateHaskellQuotes #-}
+module TH where
+
+import qualified Language.Haskell.Meta.Parse as P
+import Language.Haskell.TH.Quote
+import Language.Haskell.TH.Syntax (Exp, Q)
+import qualified Data.Text as T
+import Test.QuickCheck (counterexample)
+
+-- | Automatically adds a 'counterexample' annotation to a QuickCheck
+-- 'Test.QuickCheck.Property' indicating what expression produced the
+-- 'Test.QuickCheck.Property'.
+ann :: QuasiQuoter
+ann = doubleExp_ "ann" [| counterexample |]
+
+-- | Turns @[doubleExp| my expression |]@ into
+-- @("my expression", my expression)@. This is more flexible
+-- than `ann`, but requires slightly more optimization of test code.
+doubleExp :: QuasiQuoter
+doubleExp = doubleExp_ "doubleExp" [| (,) |]
+
+doubleExp_ :: String -> Q Exp -> QuasiQuoter
+doubleExp_ name fun = QuasiQuoter
+  { quoteExp = \s ->
+      case P.parseExp s of
+        -- I don't understand what's wrapped in Left here; I feel like it's supposed
+        -- to give some sort of source location, but it doesn't match up with anything
+        -- super-obvious.
+        Left _ -> fail $ "Could not parse expression:\n  " ++ strip s
+        Right e -> [| $fun s $(pure e) |]
+  , quotePat = \_ -> fail $ name ++ " is not for use in patterns."
+  , quoteType = \_ -> fail $ name ++ " is not for use in types."
+  , quoteDec = \_ -> fail $ name ++ " is not for creating declarations."
+  }
+
+strip :: String -> String
+strip = T.unpack . T.strip . T.pack
+{-# INLINE strip #-}


### PR DESCRIPTION
Add a quasiquoter to help add `counterexample` stuff automagically. I learned the technique a couple days ago by looking at the `dump` package. It's a bit hideous. It seems the accepted way to do this is to use another package to parse Haskell code from a string in a quasiquoter, which gives us access to both the original text of the code and the abstract representation of it. With the quasiquoter `ann` in scope, you can write

```haskell
[ann| my expression |]
```

and that will be the same as if you'd written

```haskell
counterexample "my expression" (my expression)
```